### PR TITLE
Add Logic Gate Simulator web app

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -178,3 +178,9 @@ An interactive visualization of Bézier curves using De Casteljau's algorithm.
 Path: `neural-network-visualizer/`
 
 A simple interactive visualizer for a single-layer Perceptron learning to classify 2D points.
+
+## Logic Gate Simulator
+
+Path: `logic-gate-sim/`
+
+A visual simulator for digital logic circuits, allowing users to build and test logic gates.

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
             Chaos</a></li>
         <li class="link-item"><a href="./bezier-visualizer/">Bézier Curve Visualizer</a></li>
         <li class="link-item"><a href="./neural-network-visualizer/">Neural Network Visualizer</a></li>
+        <li class="link-item"><a href="./logic-gate-sim/">Logic Gate Simulator</a></li>
       </ul>
     </main>
     <footer>

--- a/logic-gate-sim/index.html
+++ b/logic-gate-sim/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logic Gate Simulator</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="script.js" defer></script>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="../index.html" class="back-link">← Back to Index</a>
+            <h1>Logic Gate Simulator</h1>
+        </header>
+        <main>
+            <div class="toolbar">
+                <div class="tool-group">
+                    <h3>Gates</h3>
+                    <div class="tool" draggable="true" data-type="AND">AND</div>
+                    <div class="tool" draggable="true" data-type="OR">OR</div>
+                    <div class="tool" draggable="true" data-type="NOT">NOT</div>
+                    <div class="tool" draggable="true" data-type="XOR">XOR</div>
+                    <div class="tool" draggable="true" data-type="NAND">NAND</div>
+                </div>
+                <div class="tool-group">
+                    <h3>I/O</h3>
+                    <div class="tool" draggable="true" data-type="SWITCH">Switch</div>
+                    <div class="tool" draggable="true" data-type="LAMP">Lamp</div>
+                </div>
+                <div class="tool-group">
+                    <h3>Controls</h3>
+                    <button id="clear-btn">Clear All</button>
+                    <p class="instructions">Drag components to canvas. <br> Drag from pin to pin to wire. <br> Click switch to toggle.</p>
+                </div>
+            </div>
+            <div class="canvas-container">
+                <canvas id="circuit-canvas"></canvas>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/logic-gate-sim/script.js
+++ b/logic-gate-sim/script.js
@@ -1,0 +1,521 @@
+// Constants
+const GRID_SIZE = 20;
+const GATE_WIDTH = 80;
+const GATE_HEIGHT = 60;
+const PIN_RADIUS = 8;
+const WIRE_COLOR_OFF = '#555';
+const WIRE_COLOR_ON = '#00bcd4'; // Cyan for ON
+const GATE_BG = '#222';
+const GATE_BORDER = '#555';
+const GATE_BORDER_SELECTED = '#fff';
+const TEXT_COLOR = '#fff';
+
+// State
+let components = [];
+let wires = [];
+let draggingComponent = null;
+let dragOffset = { x: 0, y: 0 };
+let wiringStartPin = null;
+let mousePos = { x: 0, y: 0 };
+let idCounter = 0;
+
+// Canvas setup
+const canvas = document.getElementById('circuit-canvas');
+const ctx = canvas.getContext('2d');
+
+function resizeCanvas() {
+    canvas.width = canvas.parentElement.clientWidth;
+    canvas.height = canvas.parentElement.clientHeight;
+}
+window.addEventListener('resize', resizeCanvas);
+resizeCanvas();
+
+// Classes
+
+class Pin {
+    constructor(component, type, index, total) {
+        this.id = idCounter++;
+        this.component = component;
+        this.type = type; // 'input' or 'output'
+        this.index = index;
+        this.value = false;
+
+        // Calculate relative position based on component size
+        // Inputs on left, Outputs on right
+        const spacing = GATE_HEIGHT / (total + 1);
+        this.relY = spacing * (index + 1);
+        this.relX = type === 'input' ? 0 : GATE_WIDTH;
+    }
+
+    get pos() {
+        return {
+            x: this.component.x + this.relX,
+            y: this.component.y + this.relY
+        };
+    }
+}
+
+class Component {
+    constructor(x, y, type) {
+        this.id = idCounter++;
+        this.x = x;
+        this.y = y;
+        this.type = type;
+        this.inputs = [];
+        this.outputs = [];
+        this.width = GATE_WIDTH;
+        this.height = GATE_HEIGHT;
+        this.label = type;
+        this.setupPins();
+    }
+
+    setupPins() {
+        // Defined by subclasses
+    }
+
+    // Calculate output based on inputs
+    compute() {
+        // Defined by subclasses
+    }
+
+    draw(ctx) {
+        // Body
+        ctx.fillStyle = GATE_BG;
+        ctx.strokeStyle = (draggingComponent === this) ? GATE_BORDER_SELECTED : GATE_BORDER;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.roundRect(this.x, this.y, this.width, this.height, 6);
+        ctx.fill();
+        ctx.stroke();
+
+        // Label
+        ctx.fillStyle = TEXT_COLOR;
+        ctx.font = 'bold 14px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(this.label, this.x + this.width / 2, this.y + this.height / 2);
+
+        // Pins
+        this.drawPins(ctx, this.inputs);
+        this.drawPins(ctx, this.outputs);
+    }
+
+    drawPins(ctx, pins) {
+        pins.forEach(pin => {
+            const pos = pin.pos;
+            ctx.beginPath();
+            ctx.arc(pos.x, pos.y, PIN_RADIUS, 0, Math.PI * 2);
+            ctx.fillStyle = pin.value ? WIRE_COLOR_ON : '#444';
+            ctx.strokeStyle = '#888';
+            ctx.lineWidth = 1;
+            ctx.fill();
+            ctx.stroke();
+
+            // Hover effect for pins
+            const dx = mousePos.x - pos.x;
+            const dy = mousePos.y - pos.y;
+            if (dx * dx + dy * dy <= PIN_RADIUS * PIN_RADIUS * 1.5) {
+                ctx.strokeStyle = '#fff';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+            }
+        });
+    }
+
+    isHit(x, y) {
+        return x >= this.x && x <= this.x + this.width &&
+               y >= this.y && y <= this.y + this.height;
+    }
+
+    getPinAt(x, y) {
+        const pins = [...this.inputs, ...this.outputs];
+        for (const pin of pins) {
+            const pos = pin.pos;
+            const dx = x - pos.x;
+            const dy = y - pos.y;
+            if (dx * dx + dy * dy <= PIN_RADIUS * PIN_RADIUS * 2.5) { // Larger hit area for easy clicking
+                return pin;
+            }
+        }
+        return null;
+    }
+}
+
+class Gate extends Component {
+    constructor(x, y, type) {
+        super(x, y, type);
+    }
+
+    setupPins() {
+        const inputCount = (this.type === 'NOT') ? 1 : 2;
+        for (let i = 0; i < inputCount; i++) {
+            this.inputs.push(new Pin(this, 'input', i, inputCount));
+        }
+        this.outputs.push(new Pin(this, 'output', 0, 1));
+    }
+
+    compute() {
+        const in0 = this.inputs[0]?.value || false;
+        const in1 = this.inputs[1]?.value || false;
+        let out = false;
+
+        switch (this.type) {
+            case 'AND': out = in0 && in1; break;
+            case 'OR': out = in0 || in1; break;
+            case 'NOT': out = !in0; break;
+            case 'XOR': out = (in0 ? 1 : 0) ^ (in1 ? 1 : 0); break;
+            case 'NAND': out = !(in0 && in1); break;
+        }
+
+        this.outputs[0].value = out;
+    }
+}
+
+class Switch extends Component {
+    constructor(x, y) {
+        super(x, y, 'SWITCH');
+        this.state = false;
+        this.label = 'OFF';
+        this.width = 60;
+    }
+
+    setupPins() {
+        this.outputs.push(new Pin(this, 'output', 0, 1));
+    }
+
+    toggle() {
+        this.state = !this.state;
+        this.label = this.state ? 'ON' : 'OFF';
+    }
+
+    compute() {
+        this.outputs[0].value = this.state;
+    }
+
+    draw(ctx) {
+        ctx.fillStyle = this.state ? '#388e3c' : '#c62828';
+        ctx.strokeStyle = (draggingComponent === this) ? '#fff' : '#888';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.roundRect(this.x, this.y, this.width, this.height, 6);
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.fillStyle = '#fff';
+        ctx.font = 'bold 14px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(this.label, this.x + this.width / 2, this.y + this.height / 2);
+
+        this.drawPins(ctx, this.outputs);
+    }
+}
+
+class Lamp extends Component {
+    constructor(x, y) {
+        super(x, y, 'LAMP');
+        this.width = 60;
+        this.state = false;
+        this.label = '';
+    }
+
+    setupPins() {
+        this.inputs.push(new Pin(this, 'input', 0, 1));
+    }
+
+    compute() {
+        this.state = this.inputs[0].value;
+    }
+
+    draw(ctx) {
+        // Draw container
+        ctx.fillStyle = '#222';
+        ctx.strokeStyle = (draggingComponent === this) ? '#fff' : '#888';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.roundRect(this.x, this.y, this.width, this.height, 6);
+        ctx.fill();
+        ctx.stroke();
+
+        // Draw Bulb
+        ctx.beginPath();
+        const centerX = this.x + this.width / 2;
+        const centerY = this.y + this.height / 2;
+        const radius = 15;
+        ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+
+        if (this.state) {
+            ctx.fillStyle = '#ffeb3b';
+            ctx.shadowColor = '#ffeb3b';
+            ctx.shadowBlur = 15;
+            ctx.fill();
+            ctx.shadowBlur = 0;
+        } else {
+            ctx.fillStyle = '#444';
+            ctx.fill();
+        }
+        ctx.strokeStyle = '#fff';
+        ctx.lineWidth = 1;
+        ctx.stroke();
+
+        this.drawPins(ctx, this.inputs);
+    }
+}
+
+class Wire {
+    constructor(startPin, endPin) {
+        this.startPin = startPin;
+        this.endPin = endPin;
+    }
+
+    draw(ctx) {
+        const start = this.startPin.pos;
+        const end = this.endPin.pos;
+
+        ctx.strokeStyle = this.startPin.value ? WIRE_COLOR_ON : WIRE_COLOR_OFF;
+        ctx.lineWidth = 3;
+
+        ctx.beginPath();
+        ctx.moveTo(start.x, start.y);
+
+        // Bezier curve
+        const dist = Math.abs(end.x - start.x);
+        const cp1x = start.x + dist * 0.5;
+        const cp1y = start.y;
+        const cp2x = end.x - dist * 0.5;
+        const cp2y = end.y;
+
+        ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, end.x, end.y);
+        ctx.stroke();
+    }
+}
+
+
+// Interaction Logic
+
+let isDragging = false;
+let dragStartX = 0;
+let dragStartY = 0;
+
+function getMousePos(e) {
+    const rect = canvas.getBoundingClientRect();
+    return {
+        x: e.clientX - rect.left,
+        y: e.clientY - rect.top
+    };
+}
+
+canvas.addEventListener('mousedown', (e) => {
+    // Prevent default to avoid text selection etc
+    e.preventDefault();
+    const { x, y } = getMousePos(e);
+
+    // 1. Check Pins (Wiring)
+    for (const comp of components) {
+        const pin = comp.getPinAt(x, y);
+        if (pin) {
+            if (pin.type === 'output') {
+                wiringStartPin = pin;
+            } else {
+                // If clicking input pin, maybe disconnect existing wire?
+                // For simplicity: just allow new wires from outputs.
+            }
+            return;
+        }
+    }
+
+    // 2. Check Components
+    for (let i = components.length - 1; i >= 0; i--) {
+        const comp = components[i];
+        if (comp.isHit(x, y)) {
+            // Bring to front
+            components.splice(i, 1);
+            components.push(comp);
+
+            draggingComponent = comp;
+            dragOffset = { x: x - comp.x, y: y - comp.y };
+            isDragging = false; // Will set to true if moved
+            dragStartX = x;
+            dragStartY = y;
+            return;
+        }
+    }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+    const { x, y } = getMousePos(e);
+    mousePos = { x, y };
+
+    if (draggingComponent) {
+        const dx = x - dragStartX;
+        const dy = y - dragStartY;
+        if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
+            isDragging = true;
+        }
+
+        draggingComponent.x = x - dragOffset.x;
+        draggingComponent.y = y - dragOffset.y;
+    }
+});
+
+canvas.addEventListener('mouseup', (e) => {
+    const { x, y } = getMousePos(e);
+
+    // Finish Wiring
+    if (wiringStartPin) {
+        for (const comp of components) {
+            const pin = comp.getPinAt(x, y);
+            if (pin && pin.type === 'input') {
+                // Prevent connecting to self or same component (optional but good)
+                if (pin.component !== wiringStartPin.component) {
+                    // Remove existing wire connected to this input
+                    wires = wires.filter(w => w.endPin !== pin);
+                    wires.push(new Wire(wiringStartPin, pin));
+                }
+            }
+        }
+        wiringStartPin = null;
+    }
+
+    // Finish Dragging / Click
+    if (draggingComponent) {
+        if (!isDragging && draggingComponent.type === 'SWITCH') {
+            draggingComponent.toggle();
+        }
+        draggingComponent = null;
+    }
+
+    isDragging = false;
+});
+
+// Context Menu (Right Click) to delete
+canvas.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    const { x, y } = getMousePos(e);
+
+    // Check components
+    for (let i = components.length - 1; i >= 0; i--) {
+        const comp = components[i];
+        if (comp.isHit(x, y)) {
+            // Delete component and associated wires
+            const compPins = [...comp.inputs, ...comp.outputs];
+            wires = wires.filter(w => !compPins.includes(w.startPin) && !compPins.includes(w.endPin));
+            components.splice(i, 1);
+            return;
+        }
+    }
+
+    // Check wires? (Harder to hit detection for bezier curves)
+    // Maybe later.
+});
+
+// Drag and Drop from Toolbar
+const tools = document.querySelectorAll('.tool');
+tools.forEach(tool => {
+    tool.addEventListener('dragstart', (e) => {
+        e.dataTransfer.setData('type', tool.dataset.type);
+    });
+});
+
+canvas.addEventListener('dragover', (e) => {
+    e.preventDefault();
+});
+
+canvas.addEventListener('drop', (e) => {
+    e.preventDefault();
+    const type = e.dataTransfer.getData('type');
+    const { x, y } = getMousePos(e);
+
+    if (type) {
+        let comp;
+        const cx = x - GATE_WIDTH / 2;
+        const cy = y - GATE_HEIGHT / 2;
+
+        if (type === 'SWITCH') comp = new Switch(cx, cy);
+        else if (type === 'LAMP') comp = new Lamp(cx, cy);
+        else comp = new Gate(cx, cy, type);
+
+        components.push(comp);
+    }
+});
+
+document.getElementById('clear-btn').addEventListener('click', () => {
+    components = [];
+    wires = [];
+});
+
+// Simulation Loop
+function simulate() {
+    // 1. Reset all inputs to false first?
+    // No, inputs hold value from wires.
+    // Actually, we should clear inputs that aren't connected?
+    // Or simpler: Iterate wires to set inputs.
+
+    // Reset all inputs to default (false)
+    components.forEach(comp => {
+        comp.inputs.forEach(pin => pin.value = false);
+    });
+
+    // Propagate from outputs to inputs via wires
+    wires.forEach(wire => {
+        wire.endPin.value = wire.startPin.value;
+    });
+
+    // Compute new outputs for all components
+    components.forEach(comp => {
+        comp.compute();
+    });
+}
+
+// Animation Loop
+function animate() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // Logic Step
+    simulate();
+
+    // Draw Grid
+    ctx.strokeStyle = '#222';
+    ctx.lineWidth = 1;
+    for (let x = 0; x < canvas.width; x += GRID_SIZE) {
+        ctx.beginPath();
+        ctx.moveTo(x, 0);
+        ctx.lineTo(x, canvas.height);
+        ctx.stroke();
+    }
+    for (let y = 0; y < canvas.height; y += GRID_SIZE) {
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(canvas.width, y);
+        ctx.stroke();
+    }
+
+    // Draw Wires
+    wires.forEach(wire => wire.draw(ctx));
+
+    // Draw Wire Being Dragged
+    if (wiringStartPin) {
+        const start = wiringStartPin.pos;
+        ctx.strokeStyle = wiringStartPin.value ? WIRE_COLOR_ON : WIRE_COLOR_OFF;
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.moveTo(start.x, start.y);
+
+        const end = mousePos;
+        const dist = Math.abs(end.x - start.x);
+        const cp1x = start.x + dist * 0.5;
+        const cp1y = start.y;
+        const cp2x = end.x - dist * 0.5;
+        const cp2y = end.y;
+
+        ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, end.x, end.y);
+        ctx.stroke();
+    }
+
+    // Draw Components
+    components.forEach(comp => comp.draw(ctx));
+
+    requestAnimationFrame(animate);
+}
+
+animate();

--- a/logic-gate-sim/style.css
+++ b/logic-gate-sim/style.css
@@ -1,0 +1,138 @@
+:root {
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    --accent-color: #00bcd4;
+    --secondary-color: #333;
+    --wire-color: #555;
+    --wire-on-color: #00ff00;
+    --gate-body: #222;
+    --gate-border: #888;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+header {
+    background-color: var(--secondary-color);
+    padding: 10px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid #444;
+}
+
+h1 {
+    font-size: 1.5rem;
+    color: var(--accent-color);
+}
+
+.back-link {
+    color: var(--text-color);
+    text-decoration: none;
+    font-size: 0.9rem;
+    padding: 5px 10px;
+    background: #444;
+    border-radius: 4px;
+    transition: background 0.2s;
+}
+
+.back-link:hover {
+    background: #555;
+}
+
+main {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.toolbar {
+    width: 250px;
+    background-color: #1e1e1e;
+    border-right: 1px solid #444;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.tool-group h3 {
+    margin-bottom: 10px;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    color: #888;
+}
+
+.tool {
+    background-color: #333;
+    padding: 10px;
+    margin-bottom: 8px;
+    border-radius: 4px;
+    cursor: grab;
+    text-align: center;
+    border: 1px solid #444;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.tool:hover {
+    background-color: #444;
+    border-color: var(--accent-color);
+}
+
+.tool:active {
+    cursor: grabbing;
+}
+
+#clear-btn {
+    width: 100%;
+    padding: 10px;
+    background-color: #d32f2f;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+#clear-btn:hover {
+    background-color: #b71c1c;
+}
+
+.instructions {
+    margin-top: 10px;
+    font-size: 0.8rem;
+    color: #aaa;
+    line-height: 1.4;
+}
+
+.canvas-container {
+    flex: 1;
+    background-color: #181818;
+    position: relative;
+    overflow: hidden;
+    cursor: crosshair;
+}
+
+canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+}


### PR DESCRIPTION
Implemented a new "Logic Gate Simulator" web app as part of the Interpolnet project. The app features an interactive canvas where users can drag and drop logic gates (AND, OR, NOT, XOR, NAND) and I/O components (Switch, Lamp), wire them together, and simulate digital logic in real-time. The implementation uses vanilla JavaScript with an object-oriented design for components and a main simulation loop. The new app is correctly linked in `index.html` and documented in `Directory.md`.

---
*PR created automatically by Jules for task [877625555855088777](https://jules.google.com/task/877625555855088777) started by @rybla*